### PR TITLE
Add CandidateController with upsert endpoint and program.cs configuration

### DIFF
--- a/src/Candidate.Api/Controllers/CandidateController.cs
+++ b/src/Candidate.Api/Controllers/CandidateController.cs
@@ -1,0 +1,59 @@
+using Candidate.Api.Dtos;
+using Candidate.Api.Services;
+using Candidate.Api.Validators;
+using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Candidate.Api.Controllers;
+
+[ApiController, Route("api/[controller]")]
+public class CandidateController(
+    ILogger<CandidateController> logger,
+    ICandidateService candidateService,
+    IValidator<CandidateUpsertRequest> validator) : ControllerBase
+{
+    [HttpPut]
+    public async Task<IActionResult> UpsertAsync(
+        [FromBody] CandidateUpsertRequest candidateUpsertRequest,
+        CancellationToken abortionToken = default)
+    {
+        var validationResult = await validator.ValidateAsync(candidateUpsertRequest, abortionToken);
+        if (!validationResult.IsValid)
+        {
+            return BadRequest(validationResult.Errors);
+        }
+
+        logger.LogInformation(
+            "Candidate received: {firstName}, {lastName}, {email}",
+            candidateUpsertRequest.FirstName,
+            candidateUpsertRequest.LastName,
+            candidateUpsertRequest.Email);
+
+        try
+        {
+            var candidate = new Models.Candidate
+            {
+                FirstName = candidateUpsertRequest.FirstName!,
+                LastName = candidateUpsertRequest.LastName!,
+                Email = candidateUpsertRequest.Email!,
+                PhoneNumber = candidateUpsertRequest.PhoneNumber,
+                PreferredCallTime = candidateUpsertRequest.PreferredCallTime,
+                LinkedInUrl = candidateUpsertRequest.LinkedInUrl,
+                GitHubUrl = candidateUpsertRequest.GitHubUrl,
+                Comment = candidateUpsertRequest.Comment!
+            };
+            
+            var isNew = await candidateService.UpsertCandidateAsync(candidate, abortionToken);
+            if (isNew)
+            {
+                return Created(uri: $"api/candidates/{candidate.Id}", value: candidate);
+            }
+            return NoContent();
+        }
+        catch (NotSupportedException ex)
+        {
+            logger.LogError(ex, "Error while creating a candidate.");
+            return new StatusCodeResult(500);
+        }
+    }
+}

--- a/src/Candidate.Api/Program.cs
+++ b/src/Candidate.Api/Program.cs
@@ -1,16 +1,25 @@
 using Candidate.Api.Data;
+using Candidate.Api.Dtos;
 using Candidate.Api.Repositories;
 using Candidate.Api.Services;
+using Candidate.Api.Validators;
+using FluentValidation;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddDbContext<CandidateDbContext>(options =>  
-    options.UseNpgsql(builder.Configuration.GetConnectionString("Candidates"))); 
+    options.UseNpgsql(builder.Configuration.GetConnectionString("Candidates")));
+     
+builder.Services.AddControllers();
 
 builder.Services.AddScoped<ICandidateRepository, CandidateRepository>();
 builder.Services.AddScoped<ICandidateService, CandidateService>();
+builder.Services.AddScoped<IValidator<CandidateUpsertRequest>, CandidateUpsertRequestValidator>();
 
 var app = builder.Build();
+
+app.UseRouting();
+app.MapControllers(); 
 
 app.Run();

--- a/src/Candidate.Api/Repositories/CandidateRepository.cs
+++ b/src/Candidate.Api/Repositories/CandidateRepository.cs
@@ -8,14 +8,26 @@ public class CandidateRepository(CandidateDbContext context) : ICandidateReposit
     public async Task<Models.Candidate?> GetCandidateByEmailAsync(string email, CancellationToken cancellationToken)
         => await context.Candidates.FirstOrDefaultAsync(c => c.Email == email, cancellationToken);
 
-    public async Task UpsertCandidateAsync(Models.Candidate candidate, CancellationToken cancellationToken)
+    public async Task<bool> UpsertCandidateAsync(Models.Candidate candidate, CancellationToken cancellationToken)
     {
         var existingCandidate = await GetCandidateByEmailAsync(candidate.Email, cancellationToken);
 
         if (existingCandidate is null)
+        {
             await context.Candidates.AddAsync(candidate, cancellationToken);
-        else
-            context.Entry(existingCandidate).CurrentValues.SetValues(candidate);
+            return true;
+        }
+        
+        existingCandidate.FirstName = candidate.FirstName;
+        existingCandidate.LastName = candidate.LastName;
+        existingCandidate.Email = candidate.Email;
+        existingCandidate.PhoneNumber = candidate.PhoneNumber;
+        existingCandidate.PreferredCallTime = candidate.PreferredCallTime;
+        existingCandidate.LinkedInUrl = candidate.LinkedInUrl;
+        existingCandidate.GitHubUrl = candidate.GitHubUrl;
+        existingCandidate.Comment = candidate.Comment;
+        return false;
     }
+
     public async Task SaveChangesAsync(CancellationToken cancellationToken) => await context.SaveChangesAsync(cancellationToken);
 }

--- a/src/Candidate.Api/Repositories/ICandidateRepository.cs
+++ b/src/Candidate.Api/Repositories/ICandidateRepository.cs
@@ -3,6 +3,6 @@ namespace Candidate.Api.Repositories;
 public interface ICandidateRepository
 {
     Task<Models.Candidate?> GetCandidateByEmailAsync(string email, CancellationToken cancellationToken);
-    Task UpsertCandidateAsync(Models.Candidate candidate, CancellationToken cancellationToken);
+    Task<bool> UpsertCandidateAsync(Models.Candidate candidate, CancellationToken cancellationToken);
     Task SaveChangesAsync(CancellationToken cancellationToken);
 }

--- a/src/Candidate.Api/Services/CandidateService.cs
+++ b/src/Candidate.Api/Services/CandidateService.cs
@@ -4,9 +4,10 @@ namespace Candidate.Api.Services;
 
 public class CandidateService(ICandidateRepository repository) : ICandidateService
 {
-    public async Task UpsertCandidateAsync(Models.Candidate candidate, CancellationToken cancellationToken)
+    public async Task<bool> UpsertCandidateAsync(Models.Candidate candidate, CancellationToken cancellationToken)
     {
-        await repository.UpsertCandidateAsync(candidate, cancellationToken);
+        var isNew = await repository.UpsertCandidateAsync(candidate, cancellationToken);
         await repository.SaveChangesAsync(cancellationToken);
+        return isNew;
     }
 }

--- a/src/Candidate.Api/Services/ICandidateService.cs
+++ b/src/Candidate.Api/Services/ICandidateService.cs
@@ -2,5 +2,5 @@ namespace Candidate.Api.Services;
 
 public interface ICandidateService
 {
-    Task UpsertCandidateAsync(Models.Candidate candidate, CancellationToken cancellationToken);
+    Task<bool> UpsertCandidateAsync(Models.Candidate candidate, CancellationToken cancellationToken);
 }


### PR DESCRIPTION
- Implemented CandidateController with PUT endpoint for candidate upsert
- Updated Program.cs to add controllers, routing, and additional service registrations
- Modified repository and service layers to return boolean indicating new/updated candidate
- Added validation and error handling in the controller